### PR TITLE
do not cache if there is an article in the basket

### DIFF
--- a/controllers/ocb_staticcache_start.php
+++ b/controllers/ocb_staticcache_start.php
@@ -1,6 +1,0 @@
-<?php
-
-class ocb_staticcache_start extends ocb_staticcache_start_parent
-{
-
-}

--- a/core/ocb_staticcache.php
+++ b/core/ocb_staticcache.php
@@ -111,6 +111,10 @@ class ocb_staticcache
             return false;
         }
         
+        if($this->_hasBasketItems()){
+            return false;
+        }
+        
         return true;
     }
     
@@ -140,5 +144,14 @@ class ocb_staticcache
         $sFileName = md5($requestUrl);
        
         return getShopBasePath() . '/tmp/ocb_cache/' . $sFileName . '.json';
+    }
+    
+    protected function _hasBasketItems(){
+        $oBasket = oxRegistry::getSession()->getBasket();
+        if($oBasket && $oBasket->getProductsCount() > 0){
+            return true;
+        }
+        
+        return false;
     }
 }


### PR DESCRIPTION
Bugfix: Check if there are articles in the basket. Only if the basket is empty, the page could be cached (it was mentioned in the caching webinar). 
Remove unused controllers folder.