### PR TITLE
Fix for oxid version 4.9 (deprecated function getParameter)

### DIFF
--- a/core/ocb_staticcache.php
+++ b/core/ocb_staticcache.php
@@ -122,7 +122,13 @@ class ocb_staticcache
             return false;
         }
         $oConf = oxRegistry::getConfig();
-        $partial = $oConf->getParameter('renderPartial');
+        
+        // check for oxid version
+        if (version_compare('4.7.0', $oConf->getVersion(), '<')) {
+        	$partial = $oConf->getRequestParameter('renderPartial');
+        }else{
+        	$partial = $oConf->getParameter('renderPartial');
+        }
 
         if(!empty($partial))
         {


### PR DESCRIPTION
Check the oxid version and use the function getRequestParameter if the oxid version is greater than 4.7.0